### PR TITLE
Prevent backpacks from deleting themselves when shift-clicked into eachother

### DIFF
--- a/src/main/java/live/hisui/backpacks/item/BackpackItem.java
+++ b/src/main/java/live/hisui/backpacks/item/BackpackItem.java
@@ -6,6 +6,7 @@ import live.hisui.backpacks.block.BackpackBlock;
 import live.hisui.backpacks.block.entity.BackpackBlockEntity;
 import live.hisui.backpacks.block.entity.LargeBackpackBlockEntity;
 import live.hisui.backpacks.compat.curios.CuriosCompat;
+import live.hisui.backpacks.menu.BackpackMenu;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -18,7 +19,6 @@ import net.minecraft.world.*;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.item.Equipable;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -113,16 +113,16 @@ public class BackpackItem extends Item implements Equipable {
             BackpackContainer backpackContainer = new BackpackContainer(size, usedStack, container);
 
             // Open the menu
-            player.openMenu(getMenuProvider(backpackContainer));
+            player.openMenu(getMenuProvider(backpackContainer, usedStack));
         }
 //        level.playSound(player, BlockPos.containing(player.position()), SoundEvents.LLAMA_CHEST, SoundSource.PLAYERS, 1.0f, 0.8f);
 
         return InteractionResultHolder.success(player.getItemInHand(usedHand));
     }
 
-    public MenuProvider getMenuProvider(Container container){
+    public MenuProvider getMenuProvider(Container container, ItemStack self){
         return new SimpleMenuProvider(((containerId, playerInventory, player) ->
-                ChestMenu.threeRows(containerId, playerInventory, container)), Component.translatable("item.backpacks.backpack"));
+                BackpackMenu.smallBackpack(containerId, playerInventory, container, self)), Component.translatable("item.backpacks.backpack"));
     }
 
     @Override

--- a/src/main/java/live/hisui/backpacks/item/LargeBackpackItem.java
+++ b/src/main/java/live/hisui/backpacks/item/LargeBackpackItem.java
@@ -1,5 +1,6 @@
 package live.hisui.backpacks.item;
 
+import live.hisui.backpacks.menu.BackpackMenu;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
@@ -20,8 +21,8 @@ public class LargeBackpackItem extends BackpackItem{
     }
 
     @Override
-    public MenuProvider getMenuProvider(Container container) {
+    public MenuProvider getMenuProvider(Container container, ItemStack self) {
         return new SimpleMenuProvider(((containerId, playerInventory, player) ->
-                ChestMenu.sixRows(containerId, playerInventory, container)), Component.translatable("item.backpacks.large_backpack"));
+                BackpackMenu.largeBackpack(containerId, playerInventory, container, self)), Component.translatable("item.backpacks.large_backpack"));
     }
 }

--- a/src/main/java/live/hisui/backpacks/menu/BackpackMenu.java
+++ b/src/main/java/live/hisui/backpacks/menu/BackpackMenu.java
@@ -1,0 +1,35 @@
+package live.hisui.backpacks.menu;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+
+/*
+Extend the ChestMenu to be unable to shift-click the backpack into itself. Should fix the "backpack ouroboros" issue.
+ */
+public class BackpackMenu extends ChestMenu {
+    private final ItemStack self;
+
+    private BackpackMenu(MenuType<?> type, int containerId, Inventory playerInventory, int rows, Container container, ItemStack self) {
+        super(type, containerId, playerInventory, container, rows);
+        this.self = self;
+    }
+
+    public static BackpackMenu smallBackpack(int containerId, Inventory playerInventory, Container container, ItemStack self) {
+        return new BackpackMenu(MenuType.GENERIC_9x3, containerId, playerInventory, 3, container, self);
+    }
+
+    public static BackpackMenu largeBackpack(int containerId, Inventory playerInventory, Container container, ItemStack self) {
+        return new BackpackMenu(MenuType.GENERIC_9x6, containerId, playerInventory, 6, container, self);
+    }
+
+    @Override
+    protected boolean moveItemStackTo(ItemStack stack, int startIndex, int endIndex, boolean reverseDirection) {
+        if(ItemStack.isSameItemSameComponents(stack, self)) {
+            return false;
+        }
+        return super.moveItemStackTo(stack, startIndex, endIndex, reverseDirection);
+    }
+}

--- a/src/main/java/live/hisui/backpacks/network/OpenBackpackPacket.java
+++ b/src/main/java/live/hisui/backpacks/network/OpenBackpackPacket.java
@@ -47,7 +47,7 @@ public record OpenBackpackPacket() implements CustomPacketPayload {
                 // Create the wrapper container that will save changes back to the item
                 BackpackContainer backpackContainer = new BackpackContainer(size, backpackStack, container);
 
-                player.openMenu(((BackpackItem) backpackStack.getItem()).getMenuProvider(backpackContainer));
+                player.openMenu(((BackpackItem) backpackStack.getItem()).getMenuProvider(backpackContainer, backpackStack));
             }
         });
     }


### PR DESCRIPTION
Adds a new `BackpackMenu` (extending ChestMenu) that prevents backpacks from being inserted into themselves, which leads to the item being deleted. This fixes #3.

I'm open to extending this PR to also include the feature I mentioned in #4 if you're interested in that, but it currently does not add any config options.